### PR TITLE
Add in-memory diarization pipeline

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -61,6 +61,23 @@ Dictionary (`result_data`) containing keys:
 #### Raises
 - `senko.AudioFormatError` if audio file is not in the required 16kHz mono 16-bit WAV format
 
+### `diarize_samples()`
+```python
+result_data = diarizer.diarize_samples(samples, sample_rate=16000, accurate=None, generate_colors=False, source_name="<memory>")
+```
+#### Parameters
+- `samples`: In-memory mono PCM samples at 16kHz (`numpy.ndarray`, list, or similar)
+- `sample_rate`: Must be `16000`
+- `accurate`: Same behavior as `diarize()`
+- `generate_colors`: Same behavior as `diarize()`
+- `source_name`: Label used in progress output
+
+#### Returns
+- Same dictionary shape as `diarize()`
+
+#### Raises
+- `senko.AudioFormatError` if the input is not 16kHz mono audio
+
 ### `speaker_similarity()`
 ```python
 if senko.speaker_similarity(centroid1, centroid2) >= 0.875:

--- a/DOCS.md
+++ b/DOCS.md
@@ -66,7 +66,9 @@ Dictionary (`result_data`) containing keys:
 result_data = diarizer.diarize_samples(samples, sample_rate=16000, accurate=None, generate_colors=False, source_name="<memory>")
 ```
 #### Parameters
-- `samples`: In-memory mono PCM samples at 16kHz (`numpy.ndarray`, list, or similar)
+- `samples`: In-memory mono 16kHz audio as a `numpy.ndarray` or `torch.Tensor`
+  - Floating-point inputs must already be normalized to `[-1, 1]`
+  - Integer PCM inputs must use `uint8`, `int16`, or `int32`
 - `sample_rate`: Must be `16000`
 - `accurate`: Same behavior as `diarize()`
 - `generate_colors`: Same behavior as `diarize()`
@@ -76,7 +78,7 @@ result_data = diarizer.diarize_samples(samples, sample_rate=16000, accurate=None
 - Same dictionary shape as `diarize()`
 
 #### Raises
-- `senko.AudioFormatError` if the input is not 16kHz mono audio
+- `senko.AudioFormatError` if the input is not 16kHz mono audio or uses an unsupported/ambiguous in-memory representation
 
 ### `speaker_similarity()`
 ```python

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ wav_path = 'audio.wav' # 16kHz mono 16-bit wav
 result = diarizer.diarize(wav_path, generate_colors=False)
 
 # In-memory audio
-# samples: 1-D mono PCM array-like at 16kHz
+# samples: 1-D mono 16kHz numpy array / torch tensor
+# floats must be normalized to [-1, 1]; integer PCM dtypes: uint8, int16, int32
 result = diarizer.diarize_samples(samples, sample_rate=16000, generate_colors=False)
 
 senko.save_json(result["merged_segments"], 'audio_diarized.json')
@@ -73,7 +74,7 @@ The following modifications have been made:
 
 On Linux/WSL, both Pyannote segmentation-3.0 and CAM++ run using PyTorch, but on Mac, both models run through CoreML. The CAM++ CoreML conversion was done from scratch in this project (see [`tracing/coreml`](tracing/coreml)), but the segmentation-3.0 converted model and interfacing code is taken from the excellent [FluidAudio](https://github.com/FluidInference/FluidAudio) project by Fluid Inference.
 
-The in-memory API `diarize_samples(...)` works across the supported platforms as long as the input is already mono 16kHz PCM.
+The in-memory API `diarize_samples(...)` works across the supported platforms with 1-D mono 16kHz `numpy.ndarray` / `torch.Tensor` inputs using normalized floating-point audio in `[-1, 1]` or PCM `uint8` / `int16` / `int32` dtypes.
 
 ## Showcase
 | Application | Description |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ diarizer = senko.Diarizer(device='auto', warmup=True, quiet=False)
 wav_path = 'audio.wav' # 16kHz mono 16-bit wav
 result = diarizer.diarize(wav_path, generate_colors=False)
 
+# In-memory audio
+# samples: 1-D mono PCM array-like at 16kHz
+result = diarizer.diarize_samples(samples, sample_rate=16000, generate_colors=False)
+
 senko.save_json(result["merged_segments"], 'audio_diarized.json')
 senko.save_rttm(result["merged_segments"], wav_path, 'audio_diarized.rttm')
 ```
@@ -68,6 +72,8 @@ The following modifications have been made:
 - Clustering when on NVIDIA (with a GPU of CUDA compute capability 7.0+) can be done on the GPU through [RAPIDS](https://docs.rapids.ai/api/cuml/stable/zero-code-change/)
 
 On Linux/WSL, both Pyannote segmentation-3.0 and CAM++ run using PyTorch, but on Mac, both models run through CoreML. The CAM++ CoreML conversion was done from scratch in this project (see [`tracing/coreml`](tracing/coreml)), but the segmentation-3.0 converted model and interfacing code is taken from the excellent [FluidAudio](https://github.com/FluidInference/FluidAudio) project by Fluid Inference.
+
+The in-memory API `diarize_samples(...)` works across the supported platforms as long as the input is already mono 16kHz PCM.
 
 ## Showcase
 | Application | Description |

--- a/senko/diarizer.py
+++ b/senko/diarizer.py
@@ -177,6 +177,12 @@ class Diarizer:
                 ctypes.POINTER(ctypes.c_float), ctypes.c_size_t
             ]
             self.lib.extract_fbank_features.restype = FbankFeatures
+            self.lib.extract_fbank_features_from_memory.argtypes = [
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_float), ctypes.c_size_t,
+                ctypes.POINTER(ctypes.c_float), ctypes.c_size_t
+            ]
+            self.lib.extract_fbank_features_from_memory.restype = FbankFeatures
             self.lib.free_fbank_features.argtypes = [ctypes.POINTER(FbankFeatures)]
             self.lib.free_fbank_features.restype = None
             self.fbank_extractor = self.lib.create_fbank_extractor()
@@ -296,17 +302,7 @@ class Diarizer:
 
         # Verify correct format (16kHz mono 16-bit WAV)
         with wave.open(wav_path, 'rb') as wav_file:
-            channels = wav_file.getnchannels()
-            sample_rate = wav_file.getframerate()
-            bit_depth = wav_file.getsampwidth() * 8  # getsampwidth returns bytes, multiply by 8 for bits
-
-            if channels != 1 or sample_rate != 16000 or bit_depth != 16:
-                error_msg = f"\tError: Audio file must be 16kHz mono 16-bit WAV format.\n"
-                error_msg += f"\tCurrent format: {sample_rate}Hz, {channels} channel(s), {bit_depth}-bit\n\n"
-                error_msg += "\tTo convert your file to the correct format, run:\n"
-                error_msg += f"\tffmpeg -i {wav_path} -acodec pcm_s16le -ac 1 -ar 16000 {os.path.splitext(wav_path)[0]}_mono.wav\n"
-                self._print(colored(error_msg, 'red'))
-                raise AudioFormatError(f"Audio file must be 16kHz mono 16-bit WAV format. Current: {sample_rate}Hz, {channels} channel(s), {bit_depth}-bit")
+            self._validate_wav_file(wav_file, wav_path)
 
         # VAD (voice activity detection)
         vad_segments = self._perform_vad(wav_path)
@@ -368,22 +364,114 @@ class Diarizer:
 
         return result
 
+    def diarize_samples(self, samples, sample_rate=16000, accurate=None, generate_colors=False, source_name="<memory>"):
+        self._timing_stats = {}
+        total_start = time.time()
+
+        audio = self._normalize_audio_samples(samples, sample_rate)
+        self._print(f"\n    \033[38;2;120;167;214m{source_name}\033[0m")
+
+        vad_segments = self._perform_vad(audio)
+
+        if os.getenv("DUMP_VAD"):
+            print(f"\n    VAD segments ({len(vad_segments)}):")
+            if vad_segments:
+                for start, end in vad_segments:
+                    print(f"    - {start:.3f} -> {end:.3f}")
+            else:
+                print("    (none)")
+
+        if not vad_segments:
+            self._print(colored("\n    No speakers detected in the audio!\n", 'yellow'))
+            return None
+
+        subsegments = self._generate_subsegments(vad_segments, accurate)
+        features_flat, frames_per_subsegment, subsegment_offsets, feature_dim = self._extract_fbank_features(audio, subsegments)
+        subsegment_offsets = [int(offset) for offset in subsegment_offsets]
+        embeddings = self._generate_embeddings(features_flat, frames_per_subsegment, subsegment_offsets, feature_dim)
+        raw_segments, merged_segments, centroids = self._perform_clustering(embeddings, subsegments)
+
+        total_time = round(time.time() - total_start, 2)
+        self._timing_stats["total_time"] = total_time
+        self._print(colored(f"\n    Total diarization time: ", 'light_cyan'), end="")
+        self._print(f"{total_time:.2f}s\n")
+
+        raw_speakers_detected = len(set(segment['speaker'] for segment in raw_segments))
+        merged_speakers_detected = len(set(segment['speaker'] for segment in merged_segments))
+
+        result = {
+            "raw_segments": raw_segments,
+            "raw_speakers_detected": raw_speakers_detected,
+            "merged_speakers_detected": merged_speakers_detected,
+            "merged_segments": merged_segments,
+            "speaker_centroids": centroids,
+            "timing_stats": self._timing_stats,
+            "vad": vad_segments,
+        }
+
+        if generate_colors:
+            speaker_color_sets = {}
+            for i in range(10):
+                speaker_color_sets[str(i)] = generate_speaker_colors(merged_segments, i)
+            result["speaker_color_sets"] = speaker_color_sets
+
+        return result
+
+    def _validate_wav_file(self, wav_file, wav_path):
+        channels = wav_file.getnchannels()
+        sample_rate = wav_file.getframerate()
+        bit_depth = wav_file.getsampwidth() * 8
+
+        if channels != 1 or sample_rate != 16000 or bit_depth != 16:
+            error_msg = f"\tError: Audio file must be 16kHz mono 16-bit WAV format.\n"
+            error_msg += f"\tCurrent format: {sample_rate}Hz, {channels} channel(s), {bit_depth}-bit\n\n"
+            error_msg += "\tTo convert your file to the correct format, run:\n"
+            error_msg += f"\tffmpeg -i {wav_path} -acodec pcm_s16le -ac 1 -ar 16000 {os.path.splitext(wav_path)[0]}_mono.wav\n"
+            self._print(colored(error_msg, 'red'))
+            raise AudioFormatError(f"Audio file must be 16kHz mono 16-bit WAV format. Current: {sample_rate}Hz, {channels} channel(s), {bit_depth}-bit")
+
+    def _normalize_audio_samples(self, samples, sample_rate):
+        if sample_rate != 16000:
+            raise AudioFormatError(f"Audio samples must be 16kHz mono PCM in memory. Current sample rate: {sample_rate}Hz")
+
+        if not isinstance(samples, np.ndarray):
+            samples = np.asarray(samples)
+
+        if samples.ndim != 1:
+            raise AudioFormatError(f"Audio samples must be mono in memory. Current shape: {samples.shape}")
+
+        if np.issubdtype(samples.dtype, np.integer):
+            max_abs = max(abs(np.iinfo(samples.dtype).min), np.iinfo(samples.dtype).max)
+            samples = samples.astype(np.float32) / float(max_abs)
+        else:
+            samples = samples.astype(np.float32, copy=False)
+
+        return np.ascontiguousarray(samples)
+
     @time_method('vad_time', 'Voice activity detection')
-    def _perform_vad(self, wav_path):
+    def _perform_vad(self, audio_source):
         if self.vad_model_type == 'pyannote':
             # CUDA
             if self.device == 'cuda':
                 set_fp32_precision('ieee')
-                vad_result = self.vad_pipeline_pyannote_cuda(wav_path)
+                if isinstance(audio_source, np.ndarray):
+                    waveform = torch.from_numpy(audio_source).unsqueeze(0)
+                    vad_input = {"waveform": waveform, "sample_rate": 16000}
+                else:
+                    vad_input = audio_source
+                vad_result = self.vad_pipeline_pyannote_cuda(vad_input)
                 segments = [(segment.start, segment.end) for segment in vad_result.get_timeline()]
             # CoreML
             else:
-                segments = self.vad_processor_pyannote_coreml.process_audio(wav_path)
+                segments = self.vad_processor_pyannote_coreml.process_audio(audio_source)
         # Silero
         else:
             self._set_torch_num_threads(1)  # silero vad is single threaded
 
-            wav = self.read_audio_silero(wav_path)
+            if isinstance(audio_source, np.ndarray):
+                wav = torch.from_numpy(audio_source)
+            else:
+                wav = self.read_audio_silero(audio_source)
             speech_timestamps = self.get_speech_timestamps_silero(wav, self.vad_model_silero, threshold=0.55, min_speech_duration_ms=250, min_silence_duration_ms=100, return_seconds=False)
 
             # Convert from samples to seconds manually for full precision
@@ -423,18 +511,25 @@ class Diarizer:
         return subsegments
 
     @time_method('fbank_time', 'Fbank feature extraction')
-    def _extract_fbank_features(self, wav_path, subsegments):
+    def _extract_fbank_features(self, audio_source, subsegments):
         # GPU path: use kaldifeat when available on CUDA
         if getattr(self, 'use_gpu_fbank', False):
-            return self._extract_fbank_features_gpu(wav_path, subsegments)
+            return self._extract_fbank_features_gpu(audio_source, subsegments)
 
         # Convert subsegments to flat array
         subseg_array = np.array(subsegments, dtype=np.float32).flatten()
         subseg_ptr = subseg_array.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
 
-        # Call C++ lib function
-        wav_path_bytes = wav_path.encode('utf-8')
-        features = self.lib.extract_fbank_features(self.fbank_extractor, wav_path_bytes, subseg_ptr, len(subsegments))
+        if isinstance(audio_source, np.ndarray):
+            sample_ptr = audio_source.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+            features = self.lib.extract_fbank_features_from_memory(
+                self.fbank_extractor,
+                sample_ptr, len(audio_source),
+                subseg_ptr, len(subsegments)
+            )
+        else:
+            wav_path_bytes = audio_source.encode('utf-8')
+            features = self.lib.extract_fbank_features(self.fbank_extractor, wav_path_bytes, subseg_ptr, len(subsegments))
 
         # Convert results to numpy arrays
         total_floats = features.total_frames * features.feature_dim
@@ -453,14 +548,17 @@ class Diarizer:
 
         return features_copy, frames_per_seg_copy, subsegment_offsets_copy, features.feature_dim
 
-    def _extract_fbank_features_gpu(self, wav_path, subsegments):
+    def _extract_fbank_features_gpu(self, audio_source, subsegments):
         import torchaudio
         import torch.nn.functional as F
         
         sample_rate = 16000
         min_len = 400  # match C++ padding
-        wav, sr = torchaudio.load(wav_path)  # shape: (1, num_samples) on CPU
-        wav = wav.squeeze(0)  # drop channel dim to 1-D samples
+        if isinstance(audio_source, np.ndarray):
+            wav = torch.from_numpy(audio_source)
+        else:
+            wav, sr = torchaudio.load(audio_source)  # shape: (1, num_samples) on CPU
+            wav = wav.squeeze(0)  # drop channel dim to 1-D samples
 
         BATCH_SEGMENTS = 256
 

--- a/senko/diarizer.py
+++ b/senko/diarizer.py
@@ -430,21 +430,52 @@ class Diarizer:
             self._print(colored(error_msg, 'red'))
             raise AudioFormatError(f"Audio file must be 16kHz mono 16-bit WAV format. Current: {sample_rate}Hz, {channels} channel(s), {bit_depth}-bit")
 
+    def _coerce_audio_samples_array(self, samples):
+        if isinstance(samples, np.ndarray):
+            return samples
+
+        try:
+            import torch as torch_module
+        except ModuleNotFoundError:
+            torch_module = None
+
+        if torch_module is not None and isinstance(samples, torch_module.Tensor):
+            return samples.detach().cpu().contiguous().numpy()
+
+        raise AudioFormatError(
+            "Audio samples must be provided as a 1-D numpy.ndarray or torch.Tensor. "
+            "Plain Python sequences are unsupported because integer PCM dtype would be ambiguous."
+        )
+
     def _normalize_audio_samples(self, samples, sample_rate):
         if sample_rate != 16000:
             raise AudioFormatError(f"Audio samples must be 16kHz mono PCM in memory. Current sample rate: {sample_rate}Hz")
 
-        if not isinstance(samples, np.ndarray):
-            samples = np.asarray(samples)
+        samples = self._coerce_audio_samples_array(samples)
 
         if samples.ndim != 1:
             raise AudioFormatError(f"Audio samples must be mono in memory. Current shape: {samples.shape}")
 
-        if np.issubdtype(samples.dtype, np.integer):
-            max_abs = max(abs(np.iinfo(samples.dtype).min), np.iinfo(samples.dtype).max)
-            samples = samples.astype(np.float32) / float(max_abs)
-        else:
+        if np.issubdtype(samples.dtype, np.floating):
+            if not np.all(np.isfinite(samples)):
+                raise AudioFormatError("Floating-point audio samples must be finite")
+
+            max_abs = float(np.max(np.abs(samples))) if samples.size else 0.0
+            if max_abs > 1.0:
+                raise AudioFormatError(
+                    f"Floating-point audio samples must be normalized to [-1, 1]. Current max absolute value: {max_abs}"
+                )
             samples = samples.astype(np.float32, copy=False)
+        elif np.issubdtype(samples.dtype, np.unsignedinteger) and samples.dtype.itemsize == 1:
+            samples = (samples.astype(np.float32) - 128.0) / 128.0
+        elif np.issubdtype(samples.dtype, np.signedinteger) and samples.dtype.itemsize in (2, 4):
+            max_abs = float(1 << (samples.dtype.itemsize * 8 - 1))
+            samples = samples.astype(np.float32) / max_abs
+        else:
+            raise AudioFormatError(
+                "Unsupported in-memory audio dtype. Supported dtypes are floating-point audio normalized "
+                "to [-1, 1], uint8 PCM, int16 PCM, and int32 PCM."
+            )
 
         return np.ascontiguousarray(samples)
 

--- a/senko/fbank_extractor/cpp/fbank_extractor.cpp
+++ b/senko/fbank_extractor/cpp/fbank_extractor.cpp
@@ -277,27 +277,28 @@ private:
 
 class MemoryAudioReader {
 public:
-    explicit MemoryAudioReader(const std::vector<float>& samples) : samples_(samples) {}
+    MemoryAudioReader(const float* samples, size_t num_samples) : samples_(samples), num_samples_(num_samples) {}
 
-    size_t num_samples() const { return samples_.size(); }
+    size_t num_samples() const { return num_samples_; }
 
     bool read_samples(size_t start_frame, size_t frame_count, std::vector<float>& out) const {
-        if (frame_count == 0 || start_frame >= samples_.size()) {
+        if (frame_count == 0 || start_frame >= num_samples_) {
             out.clear();
             return true;
         }
 
-        const size_t available = samples_.size() - start_frame;
+        const size_t available = num_samples_ - start_frame;
         const size_t to_read = std::min(frame_count, available);
         out.resize(to_read);
-        std::copy(samples_.begin() + static_cast<long long>(start_frame),
-                  samples_.begin() + static_cast<long long>(start_frame + to_read),
+        std::copy(samples_ + start_frame,
+                  samples_ + start_frame + to_read,
                   out.begin());
         return true;
     }
 
 private:
-    const std::vector<float>& samples_;
+    const float* samples_ = nullptr;
+    size_t num_samples_ = 0;
 };
 
 template <typename AudioReader>
@@ -403,7 +404,7 @@ FbankResult FbankExtractor::extract_features(const std::string& wav_path, const 
     return extract_features_impl(wav_reader, subsegments);
 }
 
-FbankResult FbankExtractor::extract_features_from_memory(const std::vector<float>& samples, const std::vector<std::pair<float, float>>& subsegments) {
-    MemoryAudioReader audio_reader(samples);
+FbankResult FbankExtractor::extract_features_from_memory(const float* samples, size_t num_samples, const std::vector<std::pair<float, float>>& subsegments) {
+    MemoryAudioReader audio_reader(samples, num_samples);
     return extract_features_impl(audio_reader, subsegments);
 }

--- a/senko/fbank_extractor/cpp/fbank_extractor.cpp
+++ b/senko/fbank_extractor/cpp/fbank_extractor.cpp
@@ -3,14 +3,13 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
-#include <cmath>
-#include <iomanip>
-#include <iostream>
 #include <span>
 #include <thread>
 #include <vector>
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <io.h>
 #include <fcntl.h>
 #include <windows.h>
@@ -23,7 +22,6 @@
 #ifndef _O_BINARY
 #define _O_BINARY 0x8000
 #endif
-// pread implementation for Windows
 static long long pread_win(int fd, void* buf, size_t count, long long offset) {
     HANDLE h = (HANDLE)_get_osfhandle(fd);
     if (h == INVALID_HANDLE_VALUE) return -1;
@@ -138,11 +136,7 @@ static bool parse_wav_header(int fd, WavInfo& info) {
             fmt_found = true;
         } else if (chunk_id == "data") {
             info.data_offset = chunk_data_offset;
-            if (chunk_size == 0) {
-                info.data_size = file_size - info.data_offset;
-            } else {
-                info.data_size = static_cast<int64_t>(chunk_size);
-            }
+            info.data_size = chunk_size == 0 ? file_size - info.data_offset : static_cast<int64_t>(chunk_size);
             data_found = true;
         }
 
@@ -199,19 +193,12 @@ public:
 
     bool valid() const { return fd_ >= 0; }
     size_t num_samples() const { return total_frames_; }
-    int channels() const { return info_.channels; }
-    int bits_per_sample() const { return info_.bits_per_sample; }
-    int audio_format() const { return info_.audio_format; }
 
     bool read_samples(size_t start_frame, size_t frame_count, std::vector<float>& out) const {
         if (!valid()) {
             return false;
         }
-        if (frame_count == 0) {
-            out.clear();
-            return true;
-        }
-        if (start_frame >= total_frames_) {
+        if (frame_count == 0 || start_frame >= total_frames_) {
             out.clear();
             return true;
         }
@@ -228,7 +215,6 @@ public:
             static_cast<off_t>(start_frame * bytes_per_frame_);
 #endif
         const size_t byte_count = to_read * bytes_per_frame_;
-
         const float scale = 1.0f / 32768.0f;
 
         switch (info_.bits_per_sample) {
@@ -253,7 +239,7 @@ public:
                 break;
             }
             case 32: {
-                if (info_.audio_format == 1) { // PCM int32
+                if (info_.audio_format == 1) {
                     std::vector<int32_t> interleaved(to_read * info_.channels);
                     if (!read_fully(fd_, interleaved.data(), byte_count, byte_offset)) {
                         return false;
@@ -261,7 +247,7 @@ public:
                     for (size_t i = 0; i < to_read; ++i) {
                         out[i] = static_cast<float>(interleaved[i * info_.channels]) * scale;
                     }
-                } else if (info_.audio_format == 3) { // IEEE float
+                } else if (info_.audio_format == 3) {
                     std::vector<float> interleaved(to_read * info_.channels);
                     if (!read_fully(fd_, interleaved.data(), byte_count, byte_offset)) {
                         return false;
@@ -289,52 +275,50 @@ private:
     size_t total_frames_ = 0;
 };
 
-}  // namespace
+class MemoryAudioReader {
+public:
+    explicit MemoryAudioReader(const std::vector<float>& samples) : samples_(samples) {}
 
-FbankExtractor::FbankExtractor() {}
+    size_t num_samples() const { return samples_.size(); }
 
-FbankResult FbankExtractor::extract_features(const std::string& wav_path, const std::vector<std::pair<float, float>>& subsegments) {
+    bool read_samples(size_t start_frame, size_t frame_count, std::vector<float>& out) const {
+        if (frame_count == 0 || start_frame >= samples_.size()) {
+            out.clear();
+            return true;
+        }
 
-    /*═════════════╗
-    ║  Load audio  ║
-    ╚═════════════*/
-
-    WavStreamReader wav_reader(wav_path);
-    if (!wav_reader.valid()) {
-        return {{}, {}, {}};
+        const size_t available = samples_.size() - start_frame;
+        const size_t to_read = std::min(frame_count, available);
+        out.resize(to_read);
+        std::copy(samples_.begin() + static_cast<long long>(start_frame),
+                  samples_.begin() + static_cast<long long>(start_frame + to_read),
+                  out.begin());
+        return true;
     }
-    const size_t total_samples = wav_reader.num_samples();
 
-    /*════════════════════════════════════════════╗
-    ║  Fbank feature extraction (multi-threaded)  ║
-    ╚════════════════════════════════════════════*/
+private:
+    const std::vector<float>& samples_;
+};
+
+template <typename AudioReader>
+static FbankResult extract_features_impl(const AudioReader& audio_reader,
+                                         const std::vector<std::pair<float, float>>& subsegments) {
+    const size_t total_samples = audio_reader.num_samples();
 
     FeatureComputer fc;
-
-    // Each feature is 80 mel bins ("height") by up to ~150 frames ("width")
     constexpr size_t mel_bins = 80;
     constexpr size_t max_frames_per_subseg = 150;
     constexpr size_t sample_rate = 16000;
 
-    // Allocate a single large buffer for all subsegments
     std::vector<float> big_features(subsegments.size() * max_frames_per_subseg * mel_bins, 0.f);
-
-    // For each subsegment, track (offset_in_big_features, frames_produced)
-    std::vector<std::pair<size_t, size_t>> feature_indices(subsegments.size());
-
-    // Track frame counts for each subsegment (this is what we'll return)
     std::vector<size_t> frames_per_subsegment(subsegments.size());
     std::vector<size_t> subsegment_offsets(subsegments.size());
 
-    // Multi-threading setup
     const unsigned int feat_threads = std::max(1u, std::thread::hardware_concurrency());
     std::vector<std::thread> feat_workers;
     feat_workers.reserve(feat_threads);
 
-    // Use an atomic offset so each thread knows where to write in big_features
     std::atomic_size_t global_offset{0};
-
-    // Thread-local buffers for streaming reads and padding short segments
     thread_local static std::vector<float> segment_buffer;
     thread_local static std::vector<float> padded_buffer;
 
@@ -351,21 +335,20 @@ FbankResult FbankExtractor::extract_features(const std::string& wav_path, const 
                 sample_len = total_samples - sample_start;
             }
 
-            const size_t min_len = 400;  // Ensure a minimum of 400 samples
+            const size_t min_len = 400;
             std::span<float> wav_span;
 
             if (sample_len < min_len) {
                 if (padded_buffer.size() < min_len) padded_buffer.resize(min_len, 0.f);
                 std::fill(padded_buffer.begin(), padded_buffer.begin() + min_len, 0.f);
-                if (sample_len > 0 && wav_reader.read_samples(sample_start, sample_len, segment_buffer)) {
+                if (sample_len > 0 && audio_reader.read_samples(sample_start, sample_len, segment_buffer)) {
                     std::copy(segment_buffer.begin(),
-                             segment_buffer.begin() + sample_len,
-                             padded_buffer.begin());
+                              segment_buffer.begin() + static_cast<long long>(sample_len),
+                              padded_buffer.begin());
                 }
-                // Remaining samples in padded_buffer stay zero
                 wav_span = std::span<float>(padded_buffer.data(), min_len);
             } else {
-                if (wav_reader.read_samples(sample_start, sample_len, segment_buffer)) {
+                if (audio_reader.read_samples(sample_start, sample_len, segment_buffer)) {
                     wav_span = std::span<float>(segment_buffer.data(), sample_len);
                 } else {
                     if (padded_buffer.size() < min_len) padded_buffer.resize(min_len, 0.f);
@@ -374,30 +357,21 @@ FbankResult FbankExtractor::extract_features(const std::string& wav_path, const 
                 }
             }
 
-            // Compute FBank features => 2D: (frames x mel_bins)
             auto feat2d = fc.compute_feature(wav_span);
-            const size_t frames = feat2d.size(); // #frames generated
-
-            // Store frame count for this subsegment
+            const size_t frames = feat2d.size();
             frames_per_subsegment[i] = frames;
 
-            // Claim a chunk in big_features for these features
             const size_t my_off = global_offset.fetch_add(frames * mel_bins);
-            feature_indices[i] = {my_off, frames};
             subsegment_offsets[i] = my_off;
 
-            // Flatten-copy (frame by frame) into big_features
             size_t write_ptr = my_off;
             for (const auto& frame : feat2d) {
-                // Each frame => mel_bins floats
-                std::copy(frame.begin(), frame.end(),
-                         big_features.begin() + static_cast<long>(write_ptr));
+                std::copy(frame.begin(), frame.end(), big_features.begin() + static_cast<long>(write_ptr));
                 write_ptr += mel_bins;
             }
         }
     };
 
-    // Distribute subsegments across threads
     const size_t sub_per_thread = (subsegments.size() + feat_threads - 1) / feat_threads;
     size_t idx0 = 0;
     for (unsigned int t = 0; t < feat_threads; ++t) {
@@ -406,12 +380,30 @@ FbankResult FbankExtractor::extract_features(const std::string& wav_path, const 
         idx0 = idx1;
     }
 
-    for (auto& th : feat_workers) th.join();
+    for (auto& th : feat_workers) {
+        th.join();
+    }
 
-    // Shrink big_features to actual usage
     const size_t used_size = global_offset.load();
     big_features.resize(used_size);
     big_features.shrink_to_fit();
 
     return {big_features, frames_per_subsegment, subsegment_offsets};
+}
+
+}  // namespace
+
+FbankExtractor::FbankExtractor() {}
+
+FbankResult FbankExtractor::extract_features(const std::string& wav_path, const std::vector<std::pair<float, float>>& subsegments) {
+    WavStreamReader wav_reader(wav_path);
+    if (!wav_reader.valid()) {
+        return {{}, {}, {}};
+    }
+    return extract_features_impl(wav_reader, subsegments);
+}
+
+FbankResult FbankExtractor::extract_features_from_memory(const std::vector<float>& samples, const std::vector<std::pair<float, float>>& subsegments) {
+    MemoryAudioReader audio_reader(samples);
+    return extract_features_impl(audio_reader, subsegments);
 }

--- a/senko/fbank_extractor/cpp/fbank_extractor.h
+++ b/senko/fbank_extractor/cpp/fbank_extractor.h
@@ -15,5 +15,5 @@ public:
     ~FbankExtractor() = default;
 
     FbankResult extract_features(const std::string& wav_path, const std::vector<std::pair<float, float>>& subsegments);
-    FbankResult extract_features_from_memory(const std::vector<float>& samples, const std::vector<std::pair<float, float>>& subsegments);
+    FbankResult extract_features_from_memory(const float* samples, size_t num_samples, const std::vector<std::pair<float, float>>& subsegments);
 };

--- a/senko/fbank_extractor/cpp/fbank_extractor.h
+++ b/senko/fbank_extractor/cpp/fbank_extractor.h
@@ -15,4 +15,5 @@ public:
     ~FbankExtractor() = default;
 
     FbankResult extract_features(const std::string& wav_path, const std::vector<std::pair<float, float>>& subsegments);
+    FbankResult extract_features_from_memory(const std::vector<float>& samples, const std::vector<std::pair<float, float>>& subsegments);
 };

--- a/senko/fbank_extractor/cpp/fbank_wrapper.cpp
+++ b/senko/fbank_extractor/cpp/fbank_wrapper.cpp
@@ -68,8 +68,7 @@ extern "C" {
                                                     size_t num_subsegments) {
         auto* extractor = reinterpret_cast<FbankExtractor*>(handle);
         auto subsegments = build_subsegments(subsegments_array, num_subsegments);
-        std::vector<float> audio(samples, samples + num_samples);
-        auto result = extractor->extract_features_from_memory(audio, subsegments);
+        auto result = extractor->extract_features_from_memory(samples, num_samples, subsegments);
         return build_feature_result(result, num_subsegments);
     }
 

--- a/senko/fbank_extractor/cpp/fbank_wrapper.cpp
+++ b/senko/fbank_extractor/cpp/fbank_wrapper.cpp
@@ -6,6 +6,39 @@
 
 extern "C" {
 
+    static std::vector<std::pair<float, float>> build_subsegments(float* subsegments_array, size_t num_subsegments) {
+        std::vector<std::pair<float, float>> subsegments;
+        subsegments.reserve(num_subsegments);
+        for (size_t i = 0; i < num_subsegments; ++i) {
+            subsegments.emplace_back(subsegments_array[i*2], subsegments_array[i*2 + 1]);
+        }
+        return subsegments;
+    }
+
+    static FbankFeatures build_feature_result(const FbankResult& result, size_t num_subsegments) {
+        FbankFeatures features;
+
+        features.data = new float[result.features.size()];
+        std::memcpy(features.data, result.features.data(), result.features.size() * sizeof(float));
+
+        features.frames_per_subsegment = new size_t[result.frames_per_subsegment.size()];
+        std::memcpy(features.frames_per_subsegment, result.frames_per_subsegment.data(),
+                   result.frames_per_subsegment.size() * sizeof(size_t));
+
+        features.subsegment_offsets = new size_t[result.subsegment_offsets.size()];
+        std::memcpy(features.subsegment_offsets, result.subsegment_offsets.data(),
+                   result.subsegment_offsets.size() * sizeof(size_t));
+
+        features.num_subsegments = num_subsegments;
+        features.feature_dim = 80;
+        features.total_frames = 0;
+        for (size_t frames : result.frames_per_subsegment) {
+            features.total_frames += frames;
+        }
+
+        return features;
+    }
+
     FbankExtractorHandle create_fbank_extractor() {
         auto* extractor = new FbankExtractor();
         return reinterpret_cast<FbankExtractorHandle>(extractor);
@@ -23,44 +56,21 @@ extern "C" {
                                         float* subsegments_array,
                                         size_t num_subsegments) {
         auto* extractor = reinterpret_cast<FbankExtractor*>(handle);
-
-        // Convert subsegments array to vector of pairs
-        std::vector<std::pair<float, float>> subsegments;
-        subsegments.reserve(num_subsegments);
-        for (size_t i = 0; i < num_subsegments; ++i) {
-            subsegments.emplace_back(subsegments_array[i*2], subsegments_array[i*2 + 1]);
-        }
-
-        // Extract features
+        auto subsegments = build_subsegments(subsegments_array, num_subsegments);
         auto result = extractor->extract_features(wav_path, subsegments);
+        return build_feature_result(result, num_subsegments);
+    }
 
-        FbankFeatures features;
-
-        // Copy flattened features
-        features.data = new float[result.features.size()];
-        std::memcpy(features.data, result.features.data(), result.features.size() * sizeof(float));
-
-        // Copy frame counts
-        features.frames_per_subsegment = new size_t[result.frames_per_subsegment.size()];
-        std::memcpy(features.frames_per_subsegment, result.frames_per_subsegment.data(),
-                   result.frames_per_subsegment.size() * sizeof(size_t));
-
-        // Copy offsets
-        features.subsegment_offsets = new size_t[result.subsegment_offsets.size()];
-        std::memcpy(features.subsegment_offsets, result.subsegment_offsets.data(),
-                   result.subsegment_offsets.size() * sizeof(size_t));
-
-        // Set metadata
-        features.num_subsegments = num_subsegments;
-        features.feature_dim = 80;
-
-        // Calculate total frames
-        features.total_frames = 0;
-        for (size_t frames : result.frames_per_subsegment) {
-            features.total_frames += frames;
-        }
-
-        return features;
+    FbankFeatures extract_fbank_features_from_memory(FbankExtractorHandle handle,
+                                                    const float* samples,
+                                                    size_t num_samples,
+                                                    float* subsegments_array,
+                                                    size_t num_subsegments) {
+        auto* extractor = reinterpret_cast<FbankExtractor*>(handle);
+        auto subsegments = build_subsegments(subsegments_array, num_subsegments);
+        std::vector<float> audio(samples, samples + num_samples);
+        auto result = extractor->extract_features_from_memory(audio, subsegments);
+        return build_feature_result(result, num_subsegments);
     }
 
     void free_fbank_features(FbankFeatures* features) {

--- a/senko/fbank_extractor/include/fbank_interface.h
+++ b/senko/fbank_extractor/include/fbank_interface.h
@@ -32,6 +32,12 @@ extern "C" {
                                          const char* wav_path,
                                          float* subsegments_array,
                                          size_t num_subsegments);
+
+    FBANK_EXPORT FbankFeatures extract_fbank_features_from_memory(FbankExtractorHandle handle,
+                                         const float* samples,
+                                         size_t num_samples,
+                                         float* subsegments_array,
+                                         size_t num_subsegments);
     
     // Free features
     FBANK_EXPORT void free_fbank_features(FbankFeatures* features);

--- a/senko/vad_coreml.py
+++ b/senko/vad_coreml.py
@@ -1,5 +1,7 @@
 import ctypes
-from ctypes import c_double, c_void_p, POINTER, c_int32, c_char_p
+from ctypes import c_double, c_void_p, POINTER, c_int32, c_char_p, c_float, c_size_t
+
+import numpy as np
 
 class VADProcessorCoreML:
     def __init__(self, lib_path, model_path, min_duration_on=0.25, min_duration_off=0.1):
@@ -12,6 +14,8 @@ class VADProcessorCoreML:
         self.lib.vad_set_min_duration_off.argtypes = [c_void_p, c_double]
         self.lib.vad_process_file.argtypes = [c_void_p, c_char_p, POINTER(c_int32)]
         self.lib.vad_process_file.restype = c_void_p
+        self.lib.vad_process_samples.argtypes = [c_void_p, POINTER(c_float), c_size_t, POINTER(c_int32)]
+        self.lib.vad_process_samples.restype = c_void_p
         self.lib.vad_free_segments.argtypes = [c_void_p]
         self.lib.vad_destroy.argtypes = [c_void_p]
 
@@ -26,14 +30,24 @@ class VADProcessorCoreML:
         if not self.lib.vad_load_model(self.processor, model_path.encode('utf-8')):
             raise RuntimeError(f"Failed to load model from {model_path}")
 
-    def process_audio(self, audio_path):
-        """Process audio file and return VAD segments"""
+    def process_audio(self, audio_source):
+        """Process a WAV path or in-memory float32 mono samples and return VAD segments."""
         count = c_int32()
-        segments_ptr = self.lib.vad_process_file(
-            self.processor,
-            str(audio_path).encode('utf-8'),
-            ctypes.byref(count)
-        )
+
+        if isinstance(audio_source, np.ndarray):
+            audio = np.ascontiguousarray(audio_source, dtype=np.float32)
+            segments_ptr = self.lib.vad_process_samples(
+                self.processor,
+                audio.ctypes.data_as(POINTER(c_float)),
+                audio.size,
+                ctypes.byref(count)
+            )
+        else:
+            segments_ptr = self.lib.vad_process_file(
+                self.processor,
+                str(audio_source).encode('utf-8'),
+                ctypes.byref(count)
+            )
 
         if not segments_ptr or count.value == 0:
             return []

--- a/senko/vad_coreml/vad_lib.swift
+++ b/senko/vad_coreml/vad_lib.swift
@@ -433,6 +433,49 @@ private func parseWavHeader(fd: Int32) throws -> WavInfo {
         }
     }
 
+    @objc public func processAudioSamples(_ samples: [Float]) -> [VADSegment] {
+        guard let model = segmentationModel else {
+            print("Model not loaded")
+            return []
+        }
+
+        guard !samples.isEmpty else {
+            return []
+        }
+
+        var allSegments: [VADSegment] = []
+        let batchSize = 64
+        var batch: [(ArraySlice<Float>, Double)] = []
+        batch.reserveCapacity(batchSize)
+
+        var offsetSamples = 0
+        while offsetSamples < samples.count {
+            let samplesToRead = min(chunkSize, samples.count - offsetSamples)
+            if samplesToRead <= 0 {
+                break
+            }
+
+            let endOffset = offsetSamples + samplesToRead
+            let chunkOffsetTime = Double(offsetSamples) / Double(sampleRate)
+            batch.append((samples[offsetSamples..<endOffset], chunkOffsetTime))
+
+            if batch.count >= batchSize {
+                let batchSegments = processBatch(batch, model: model)
+                allSegments.append(contentsOf: batchSegments)
+                batch.removeAll(keepingCapacity: true)
+            }
+
+            offsetSamples = endOffset
+        }
+
+        if !batch.isEmpty {
+            let batchSegments = processBatch(batch, model: model)
+            allSegments.append(contentsOf: batchSegments)
+        }
+
+        return mergeSegments(allSegments)
+    }
+
     private func processStreamedWav(at path: String, model: MLModel) throws -> [VADSegment] {
         let fd = open(path, O_RDONLY)
         if fd < 0 {
@@ -887,6 +930,32 @@ public func vad_process_file(
     }
 
     // Allocate memory for doubles (start, end pairs)
+    let buffer = UnsafeMutablePointer<Double>.allocate(capacity: segments.count * 2)
+    for (i, seg) in segments.enumerated() {
+        buffer[i * 2] = seg.start
+        buffer[i * 2 + 1] = seg.end
+    }
+
+    return UnsafeMutableRawPointer(buffer)
+}
+
+@_cdecl("vad_process_samples")
+public func vad_process_samples(
+    _ processorPtr: UnsafeMutableRawPointer,
+    _ samplesPtr: UnsafePointer<Float>,
+    _ sampleCount: Int,
+    _ count: UnsafeMutablePointer<Int32>
+) -> UnsafeMutableRawPointer {
+    let processor = Unmanaged<VADProcessor>.fromOpaque(processorPtr).takeUnretainedValue()
+    let samples = Array(UnsafeBufferPointer(start: samplesPtr, count: sampleCount))
+
+    let segments = processor.processAudioSamples(samples)
+    count.pointee = Int32(segments.count)
+
+    guard segments.count > 0 else {
+        return UnsafeMutableRawPointer(bitPattern: 1)!
+    }
+
     let buffer = UnsafeMutablePointer<Double>.allocate(capacity: segments.count * 2)
     for (i, seg) in segments.enumerated() {
         buffer[i * 2] = seg.start

--- a/senko/vad_coreml/vad_lib.swift
+++ b/senko/vad_coreml/vad_lib.swift
@@ -258,6 +258,12 @@ private struct WavParseError: Error, LocalizedError {
     var errorDescription: String? { message }
 }
 
+private struct BorrowedAudioChunk {
+    let startIndex: Int
+    let sampleCount: Int
+    let chunkOffset: Double
+}
+
 private func parseWavHeader(fd: Int32) throws -> WavInfo {
     var statBuf = stat()
     guard fstat(fd, &statBuf) == 0 else {
@@ -433,43 +439,46 @@ private func parseWavHeader(fd: Int32) throws -> WavInfo {
         }
     }
 
-    @objc public func processAudioSamples(_ samples: [Float]) -> [VADSegment] {
+    public func processAudioSamples(_ samplesPtr: UnsafePointer<Float>, sampleCount: Int) -> [VADSegment] {
         guard let model = segmentationModel else {
             print("Model not loaded")
             return []
         }
 
-        guard !samples.isEmpty else {
+        guard sampleCount > 0 else {
             return []
         }
 
         var allSegments: [VADSegment] = []
         let batchSize = 64
-        var batch: [(ArraySlice<Float>, Double)] = []
+        var batch: [BorrowedAudioChunk] = []
         batch.reserveCapacity(batchSize)
 
         var offsetSamples = 0
-        while offsetSamples < samples.count {
-            let samplesToRead = min(chunkSize, samples.count - offsetSamples)
+        while offsetSamples < sampleCount {
+            let samplesToRead = min(chunkSize, sampleCount - offsetSamples)
             if samplesToRead <= 0 {
                 break
             }
 
-            let endOffset = offsetSamples + samplesToRead
             let chunkOffsetTime = Double(offsetSamples) / Double(sampleRate)
-            batch.append((samples[offsetSamples..<endOffset], chunkOffsetTime))
+            batch.append(BorrowedAudioChunk(
+                startIndex: offsetSamples,
+                sampleCount: samplesToRead,
+                chunkOffset: chunkOffsetTime
+            ))
 
             if batch.count >= batchSize {
-                let batchSegments = processBatch(batch, model: model)
+                let batchSegments = processBatch(samplesPtr: samplesPtr, batch: batch, model: model)
                 allSegments.append(contentsOf: batchSegments)
                 batch.removeAll(keepingCapacity: true)
             }
 
-            offsetSamples = endOffset
+            offsetSamples += samplesToRead
         }
 
         if !batch.isEmpty {
-            let batchSegments = processBatch(batch, model: model)
+            let batchSegments = processBatch(samplesPtr: samplesPtr, batch: batch, model: model)
             allSegments.append(contentsOf: batchSegments)
         }
 
@@ -601,6 +610,42 @@ private func parseWavHeader(fd: Int32) throws -> WavInfo {
         return allSegments
     }
 
+    // Process a batch of borrowed chunks concurrently
+    private func processBatch(samplesPtr: UnsafePointer<Float>, batch: [BorrowedAudioChunk], model: MLModel) -> [VADSegment] {
+        var allSegments: [VADSegment] = []
+        let semaphore = DispatchSemaphore(value: 0)
+        let queue = DispatchQueue.global(qos: .userInitiated)
+        var results: [[VADSegment]?] = Array(repeating: nil, count: batch.count)
+
+        // Process each chunk in the batch concurrently
+        for (index, chunk) in batch.enumerated() {
+            queue.async {
+                do {
+                    let segments = try self.processChunkOptimized(samplesPtr: samplesPtr, chunk: chunk, model: model)
+                    results[index] = segments
+                } catch {
+                    print("Error processing chunk: \(error)")
+                    results[index] = []
+                }
+                semaphore.signal()
+            }
+        }
+
+        // Wait for all chunks to complete
+        for _ in 0..<batch.count {
+            semaphore.wait()
+        }
+
+        // Collect results in order
+        for segments in results {
+            if let segments = segments {
+                allSegments.append(contentsOf: segments)
+            }
+        }
+
+        return allSegments
+    }
+
     // Optimized chunk processing with buffer reuse
     private func processChunkOptimized(_ audioChunk: ArraySlice<Float>, model: MLModel, chunkOffset: Double) throws -> [VADSegment] {
         // Get pooled buffer for this thread
@@ -656,6 +701,64 @@ private func parseWavHeader(fd: Int32) throws -> WavInfo {
 
         // Process segments with optimized memory access
         return processSegmentsOptimized(segmentOutput, chunkOffset: chunkOffset)
+    }
+
+    // Optimized chunk processing with buffer reuse
+    private func processChunkOptimized(samplesPtr: UnsafePointer<Float>, chunk: BorrowedAudioChunk, model: MLModel) throws -> [VADSegment] {
+        // Get pooled buffer for this thread
+        let threadId = Thread.current.description
+        let bufferKey = "audio_buffer_\(threadId)"
+
+        // Get or create ANE-aligned buffer from pool
+        let audioArray = try memoryOptimizer.getPooledBuffer(
+            key: bufferKey,
+            shape: [1, 1, NSNumber(value: chunkSize)],
+            dataType: .float32
+        )
+
+        // Clear buffer first (important for reuse)
+        let ptr = audioArray.dataPointer.assumingMemoryBound(to: Float.self)
+        memset(ptr, 0, chunkSize * MemoryLayout<Float>.size)
+
+        // Borrow from the caller-owned waveform and only copy the current chunk
+        let copyCount = min(chunk.sampleCount, chunkSize)
+        if copyCount > 0 {
+            let sourcePtr = samplesPtr.advanced(by: chunk.startIndex)
+            vDSP_mmov(
+                sourcePtr,
+                ptr,
+                vDSP_Length(copyCount),
+                vDSP_Length(1),
+                vDSP_Length(1),
+                vDSP_Length(copyCount)
+            )
+        }
+
+        // Create zero-copy feature provider
+        let featureProvider = ZeroCopyDiarizerFeatureProvider(features: [
+            "audio": MLFeatureValue(multiArray: audioArray)
+        ])
+
+        // Configure prediction for ANE
+        let options = MLPredictionOptions()
+
+        // Use async prediction if available for better ANE scheduling
+        let output: MLFeatureProvider
+        if #available(macOS 14.0, iOS 17.0, *) {
+            // Prefetch to ANE
+            audioArray.prefetchToNeuralEngine()
+            // Use async for better scheduling
+            output = try model.prediction(from: featureProvider, options: options)
+        } else {
+            output = try model.prediction(from: featureProvider, options: options)
+        }
+
+        guard let segmentOutput = output.featureValue(for: "segments")?.multiArrayValue else {
+            return []
+        }
+
+        // Process segments with optimized memory access
+        return processSegmentsOptimized(segmentOutput, chunkOffset: chunk.chunkOffset)
     }
 
     private func processSegmentsOptimized(_ segmentOutput: MLMultiArray, chunkOffset: Double) -> [VADSegment] {
@@ -947,9 +1050,7 @@ public func vad_process_samples(
     _ count: UnsafeMutablePointer<Int32>
 ) -> UnsafeMutableRawPointer {
     let processor = Unmanaged<VADProcessor>.fromOpaque(processorPtr).takeUnretainedValue()
-    let samples = Array(UnsafeBufferPointer(start: samplesPtr, count: sampleCount))
-
-    let segments = processor.processAudioSamples(samples)
+    let segments = processor.processAudioSamples(samplesPtr, sampleCount: sampleCount)
     count.pointee = Int32(segments.count)
 
     guard segments.count > 0 else {


### PR DESCRIPTION
This pull request introduces support for in-memory diarization, allowing users to run speaker diarization directly on mono PCM audio samples (as `numpy` arrays or similar) instead of requiring a WAV file. The implementation includes a new `diarize_samples()` API, updates to documentation and usage examples, and changes to the feature extraction pipeline to support both file-based and memory-based audio input. Some modifications were also made for clarity and maintainability.

The most important changes are:

- Added a `diarize_samples()` method to the `Diarizer` class, enabling diarization directly from in-memory mono PCM audio samples at 16kHz. This includes input validation, VAD, feature extraction, clustering, and color generation, mirroring the existing file-based workflow. 
- Refactored the feature extraction logic to support both file-based and in-memory audio sources, including a new `extract_fbank_features_from_memory` C++ function and corresponding Python bindings. Added a `MemoryAudioReader` class in C++ for handling in-memory sample arrays. 
- Updated GPU and CPU feature extraction paths to accept either a file path or a `numpy` array, ensuring support for both input types.
- Extracted WAV file format validation into a dedicated `_validate_wav_file` method for clarity and reuse. 
- Simplified and clarified type and argument handling in the C++ and Python code, including error handling and sample reading logic. 

* Updated `README.md` and `DOCS.md` 

These changes enable efficient, flexible diarization workflows for both file-based and in-memory audio data. In my use case, it is important to leave no trace of the audio on disk for maximum privacy/confidentiality.
